### PR TITLE
Implement ranking listing and clean submenus

### DIFF
--- a/services/point_service.py
+++ b/services/point_service.py
@@ -40,3 +40,10 @@ class PointService:
     async def get_user_points(self, user_id: int) -> int:
         user = await self.session.get(User, user_id)
         return user.points if user else 0
+
+    async def get_top_users(self, limit: int = 10) -> list[User]:
+        """Return the top users ordered by points."""
+        stmt = select(User).order_by(User.points.desc()).limit(limit)
+        result = await self.session.execute(stmt)
+        top_users = result.scalars().all()
+        return top_users

--- a/utils/keyboard_utils.py
+++ b/utils/keyboard_utils.py
@@ -15,7 +15,6 @@ def get_main_menu_keyboard():
 def get_profile_keyboard():
     """Returns the keyboard for the profile section."""
     keyboard = [
-        [InlineKeyboardButton(text="⬅️ Volver", callback_data="menu:back")],
         [InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
@@ -36,7 +35,6 @@ def get_missions_keyboard(missions: list, offset: int = 0):
     if nav_buttons:
         keyboard.append(nav_buttons)
 
-    keyboard.append([InlineKeyboardButton(text="⬅️ Volver", callback_data="menu:back")])
     keyboard.append([InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")])
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
@@ -46,7 +44,6 @@ def get_reward_keyboard(rewards: list):
     keyboard = []
     for reward in rewards:
         keyboard.append([InlineKeyboardButton(text=f"{reward.name} ({reward.cost} Pts)", callback_data=f"buy_reward_{reward.id}")])
-    keyboard.append([InlineKeyboardButton(text="⬅️ Volver", callback_data="menu:back")])
     keyboard.append([InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")])
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
@@ -61,7 +58,6 @@ def get_confirm_purchase_keyboard(reward_id: int):
 def get_ranking_keyboard():
     """Returns the keyboard for the ranking section."""
     keyboard = [
-        [InlineKeyboardButton(text="⬅️ Volver", callback_data="menu:back")],
         [InlineKeyboardButton(text="🏠 Menú Principal", callback_data="menu_principal")]
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)


### PR DESCRIPTION
## Summary
- fetch top players via `PointService.get_top_users`
- simplify submenu keyboards by removing duplicated "Regresar" buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de45c5f688329b2dd59a2ef20e853