### PR TITLE
Add admin menu detection

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -56,7 +56,55 @@ async def admin_panel(message: Message):
     if message.from_user.id != Config.ADMIN_ID:
         await message.answer("Acceso denegado. No eres administrador.")
         return
-    await message.answer("Bienvenido al panel de administración, Diana.", reply_markup=get_admin_main_keyboard())
+    await message.answer(
+        "Bienvenido al panel de administración, Diana.",
+        reply_markup=get_admin_main_keyboard(),
+    )
+
+
+@router.callback_query(F.data == "admin_manage_users")
+async def admin_manage_users(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Gestión de usuarios en desarrollo.", reply_markup=get_admin_main_keyboard()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_manage_content")
+async def admin_manage_content(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Gestión de contenido en desarrollo.", reply_markup=get_admin_main_keyboard()
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_manage_events_sorteos")
+async def admin_manage_events_sorteos(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Gestión de eventos y sorteos en desarrollo.",
+        reply_markup=get_admin_main_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_bot_config")
+async def admin_bot_config(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Configuración del bot en desarrollo.", reply_markup=get_admin_main_keyboard()
+    )
+    await callback.answer()
 
 
 @router.callback_query(F.data == "admin_create_reward")

--- a/handlers/user_handlers.py
+++ b/handlers/user_handlers.py
@@ -46,22 +46,28 @@ async def cmd_start(message: Message, session: AsyncSession):
             first_name=first_name,
             last_name=last_name,
             points=0,
-            level=1
+            level=1,
         )
         session.add(new_user)
         await session.commit()
         await session.refresh(new_user)
         logger.info(f"New user registered: {user_id} - {username}")
-        await message.answer(
-            BOT_MESSAGES["start_welcome_new_user"],
-            reply_markup=get_main_reply_keyboard() # Usar el teclado de respuesta principal
-        )
+
     else:
         # Usuario existente
         logger.info(f"Returning user: {user_id} - {username}")
+
+    if user_id == Config.ADMIN_ID:
         await message.answer(
-            BOT_MESSAGES["start_welcome_returning_user"],
-            reply_markup=get_main_reply_keyboard() # Usar el teclado de respuesta principal
+            "Bienvenido al panel de administración, Diana.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+    else:
+        await message.answer(
+            BOT_MESSAGES["start_welcome_returning_user"]
+            if user
+            else BOT_MESSAGES["start_welcome_new_user"],
+            reply_markup=get_main_reply_keyboard(),
         )
     # Establecer el estado inicial del menú
     await set_user_menu_state(session, user_id, "root")

--- a/utils/keyboard_utils.py
+++ b/utils/keyboard_utils.py
@@ -73,17 +73,12 @@ def get_reaction_keyboard(message_id: int):
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 def get_admin_main_keyboard():
-    """Returns the main keyboard for admin actions."""
+    """Returns the top level keyboard for admin actions."""
     keyboard = InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="➕ Crear Recompensa", callback_data="admin_create_reward")],
-        [InlineKeyboardButton(text="📝 Gestionar Recompensas", callback_data="admin_manage_rewards")],
-        [InlineKeyboardButton(text="➕ Crear Misión", callback_data="admin_create_mission")],
-        [InlineKeyboardButton(text="📝 Gestionar Misiones", callback_data="admin_manage_missions")],
-        [InlineKeyboardButton(text="➕ Crear Evento", callback_data="admin_create_event")],
-        [InlineKeyboardButton(text="📝 Gestionar Eventos", callback_data="admin_manage_events")],
-        [InlineKeyboardButton(text="📊 Ver Estadísticas", callback_data="admin_stats")],
-        [InlineKeyboardButton(text="💰 Asignar Puntos", callback_data="admin_assign_points")],
-        [InlineKeyboardButton(text="📢 Enviar mensaje con reacciones al Canal", callback_data="admin_send_channel_post_reactions")],
+        [InlineKeyboardButton(text="🧑‍💼 Gestionar Usuarios", callback_data="admin_manage_users")],
+        [InlineKeyboardButton(text="🎮 Gestionar Contenido/Juego", callback_data="admin_manage_content")],
+        [InlineKeyboardButton(text="🎉 Gestionar Eventos y Sorteos", callback_data="admin_manage_events_sorteos")],
+        [InlineKeyboardButton(text="⚙️ Configuración del Bot", callback_data="admin_bot_config")],
         [InlineKeyboardButton(text="🔙 Menú Principal", callback_data="menu_principal")]
     ])
     return keyboard


### PR DESCRIPTION
## Summary
- update admin menu keyboard with new sections
- add handlers for admin menu sections
- show admin menu on /start for admin users

## Testing
- `flake8` *(fails: command not found or style issues)*
- `python -m py_compile handlers/admin_handlers.py handlers/user_handlers.py utils/keyboard_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684de76a69fc8329997a39d0acefc7e0