### PR TITLE
Add user management menu for admin

### DIFF
--- a/utils/keyboard_utils.py
+++ b/utils/keyboard_utils.py
@@ -83,6 +83,18 @@ def get_admin_main_keyboard():
     ])
     return keyboard
 
+def get_admin_manage_users_keyboard():
+    """Returns the keyboard for user management options in the admin panel."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="➕ Sumar Puntos a Usuario", callback_data="admin_add_points")],
+        [InlineKeyboardButton(text="➖ Restar Puntos a Usuario", callback_data="admin_deduct_points")],
+        [InlineKeyboardButton(text="🔍 Ver Perfil de Usuario", callback_data="admin_view_user")],
+        [InlineKeyboardButton(text="🔎 Buscar Usuario", callback_data="admin_search_user")],
+        [InlineKeyboardButton(text="📢 Notificar a Usuarios", callback_data="admin_notify_users")],
+        [InlineKeyboardButton(text="🔙 Volver al Menú Principal de Administrador", callback_data="admin_main_menu")]
+    ])
+    return keyboard
+
 # --- Funciones para la navegación de menú ---
 # Estas funciones están más orientadas a la lógica de estado que a la creación de teclados per se,
 # pero se mantienen aquí para compatibilidad si las usas para generar teclados dinámicos.


### PR DESCRIPTION
## Summary
- extend admin keyboard with user management options
- implement admin_manage_users submenu
- add handlers to add/rest points, view and search users, notify users
- support returning to admin main menu

## Testing
- `python -m py_compile handlers/admin_handlers.py utils/keyboard_utils.py`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684def715608832997e332fb1ad92d8d