### PR TITLE
Add admin content menu skeleton

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -22,6 +22,13 @@ from utils.keyboard_utils import (
     get_main_menu_keyboard,
     get_reaction_keyboard,
     get_admin_manage_users_keyboard,
+    get_admin_manage_content_keyboard,
+    get_admin_content_missions_keyboard,
+    get_admin_content_badges_keyboard,
+    get_admin_content_levels_keyboard,
+    get_admin_content_rewards_keyboard,
+    get_admin_content_auctions_keyboard,
+    get_admin_content_daily_gifts_keyboard,
 )
 from utils.message_utils import get_profile_message
 from config import Config
@@ -228,7 +235,219 @@ async def admin_manage_content(callback: CallbackQuery):
         await callback.answer("Acceso denegado", show_alert=True)
         return
     await callback.message.edit_text(
-        "Gestión de contenido en desarrollo.", reply_markup=get_admin_main_keyboard()
+        "🎮 *Gestionar Contenido / Juego* - Selecciona una categoría:",
+        reply_markup=get_admin_manage_content_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_missions")
+async def admin_content_missions(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "📌 *Misiones* - Selecciona una opción:",
+        reply_markup=get_admin_content_missions_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_badges")
+async def admin_content_badges(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "🏅 *Insignias* - Selecciona una opción:",
+        reply_markup=get_admin_content_badges_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_levels")
+async def admin_content_levels(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "📈 *Niveles* - Selecciona una opción:",
+        reply_markup=get_admin_content_levels_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_rewards")
+async def admin_content_rewards(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "🎁 *Recompensas (Catálogo VIP)* - Selecciona una opción:",
+        reply_markup=get_admin_content_rewards_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_auctions")
+async def admin_content_auctions(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "📦 *Subastas* - Selecciona una opción:",
+        reply_markup=get_admin_content_auctions_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_content_daily_gifts")
+async def admin_content_daily_gifts(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "🎁 *Regalos Diarios* - Selecciona una opción:",
+        reply_markup=get_admin_content_daily_gifts_keyboard(),
+        parse_mode="Markdown",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_toggle_mission")
+async def admin_toggle_mission(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_missions_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_view_active_missions")
+async def admin_view_active_missions(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_missions_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_give_badge_manual")
+async def admin_give_badge_manual(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_badges_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_manage_badges")
+async def admin_manage_badges(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_badges_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_adjust_levels")
+async def admin_adjust_levels(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_levels_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_edit_reward")
+async def admin_edit_reward(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_rewards_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_view_claimed_rewards")
+async def admin_view_claimed_rewards(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_rewards_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_create_auction")
+async def admin_create_auction(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_auctions_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_view_auctions")
+async def admin_view_auctions(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_auctions_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_finish_auction")
+async def admin_finish_auction(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_auctions_keyboard(),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_configure_daily_gift")
+async def admin_configure_daily_gift(callback: CallbackQuery):
+    if callback.from_user.id != Config.ADMIN_ID:
+        await callback.answer("Acceso denegado", show_alert=True)
+        return
+    await callback.message.edit_text(
+        "Funcionalidad en desarrollo.",
+        reply_markup=get_admin_content_daily_gifts_keyboard(),
     )
     await callback.answer()
 

--- a/utils/keyboard_utils.py
+++ b/utils/keyboard_utils.py
@@ -95,6 +95,74 @@ def get_admin_manage_users_keyboard():
     ])
     return keyboard
 
+def get_admin_manage_content_keyboard():
+    """Returns the keyboard for content management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="📌 Misiones", callback_data="admin_content_missions")],
+        [InlineKeyboardButton(text="🏅 Insignias", callback_data="admin_content_badges")],
+        [InlineKeyboardButton(text="📈 Niveles", callback_data="admin_content_levels")],
+        [InlineKeyboardButton(text="🎁 Recompensas (Catálogo VIP)", callback_data="admin_content_rewards")],
+        [InlineKeyboardButton(text="📦 Subastas", callback_data="admin_content_auctions")],
+        [InlineKeyboardButton(text="🎁 Regalos Diarios", callback_data="admin_content_daily_gifts")],
+        [InlineKeyboardButton(text="🔙 Volver al Menú Principal de Administrador", callback_data="admin_main_menu")]
+    ])
+    return keyboard
+
+def get_admin_content_missions_keyboard():
+    """Keyboard for mission management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="✏️ Crear Misión", callback_data="admin_create_mission")],
+        [InlineKeyboardButton(text="🔄 Activar / Desactivar Misión", callback_data="admin_toggle_mission")],
+        [InlineKeyboardButton(text="📃 Ver Misiones Activas", callback_data="admin_view_active_missions")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
+def get_admin_content_badges_keyboard():
+    """Keyboard for badge management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="🏆 Otorgar Insignia Manualmente", callback_data="admin_give_badge_manual")],
+        [InlineKeyboardButton(text="⚙️ Gestionar Insignias", callback_data="admin_manage_badges")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
+def get_admin_content_levels_keyboard():
+    """Keyboard for level management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="🧩 Ajustar Niveles", callback_data="admin_adjust_levels")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
+def get_admin_content_rewards_keyboard():
+    """Keyboard for reward catalogue management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="➕ Añadir Recompensa", callback_data="admin_create_reward")],
+        [InlineKeyboardButton(text="✏️ Editar / Eliminar Recompensa", callback_data="admin_edit_reward")],
+        [InlineKeyboardButton(text="📦 Ver Recompensas Canjeadas", callback_data="admin_view_claimed_rewards")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
+def get_admin_content_auctions_keyboard():
+    """Keyboard for auction management options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="🛒 Crear Subasta", callback_data="admin_create_auction")],
+        [InlineKeyboardButton(text="📋 Ver Subastas Activas / Finalizadas", callback_data="admin_view_auctions")],
+        [InlineKeyboardButton(text="⛔ Finalizar Subasta Manualmente", callback_data="admin_finish_auction")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
+def get_admin_content_daily_gifts_keyboard():
+    """Keyboard for daily gift configuration options."""
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="🎯 Configurar Regalo del Día", callback_data="admin_configure_daily_gift")],
+        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")]
+    ])
+    return keyboard
+
 # --- Funciones para la navegación de menú ---
 # Estas funciones están más orientadas a la lógica de estado que a la creación de teclados per se,
 # pero se mantienen aquí para compatibilidad si las usas para generar teclados dinámicos.


### PR DESCRIPTION
## Summary
- add new admin content management keyboards
- update admin handler to show content management menu and placeholders

## Testing
- `flake8 | head -n 5`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684df177a9988329a8b26f983b960ecd