### PR TITLE
Fix token link display

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -477,6 +477,7 @@ async def admin_generate_token(callback: CallbackQuery, session: AsyncSession, b
     await callback.message.edit_text(
         f"Token generado:\n{invite_link}",
         reply_markup=get_admin_main_keyboard(),
+        parse_mode=None,
     )
     await callback.answer()
 

--- a/handlers/user_handlers.py
+++ b/handlers/user_handlers.py
@@ -93,7 +93,8 @@ async def cmd_start(message: Message, session: AsyncSession, bot: Bot):
                 member_limit=1,
             )
             await message.answer(
-                f"Aquí está tu enlace de invitación:\n{invite.invite_link}"
+                f"Aquí está tu enlace de invitación:\n{invite.invite_link}",
+                parse_mode=None,
             )
         else:
             await message.answer("Token inválido o expirado.")


### PR DESCRIPTION
## Summary
- show generated token without Markdown parsing
- disable Markdown for invite links

## Testing
- `python -m py_compile handlers/admin_handlers.py handlers/user_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_684df845b2688329b08b6b8e6828a378